### PR TITLE
mount_linux: implement hanwen's poll hack for fixing test deadlock

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -282,6 +282,9 @@ func (h HandleID) String() string {
 // The RootID identifies the root directory of a FUSE file system.
 const RootID NodeID = rootID
 
+const PollHackName = ".bazil-fuse-epoll-hack"
+const PollHackInode = NodeID(^uint64(0))
+
 // A Header describes the basic information sent in every request.
 type Header struct {
 	Conn *Conn     `json:"-"` // connection this request was received on


### PR DESCRIPTION
The idea for this fix, and most of the code from it, should be credited to hanwen, from commit 4f10e248e of the hanwen/go-fuse repo.

Briefly, on Linux, when the same process that's serving a fuse mountpoint is sending epoll requests to that mountpoint (as is common in tests), the go runtime can deadlock.  This works around the issue with a nasty hack that forces the kernel to learn (and cache) the fact that polling is not implemented right after the mount happens, to avoid deadlocks when the test later makes the same request.

Issue: golang/go#21014
Issue: hanwen/go-fuse#165
Issue: bazil/fuse#183